### PR TITLE
Finish section20 dynamic args

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Effective Python のコードメモ
 16. [リストを返す代わりにジェネレータを検討しよう](https://github.com/ku2ma2/effectivepython/blob/master/chapter02/sec16_consider_generator.py)
 17. [引数を介したイテレーションは防御的に行う](https://github.com/ku2ma2/effectivepython/blob/master/chapter02/sec17_defensive_iterator.py)
 18. [可変長引数で視認性をあげる](https://github.com/ku2ma2/effectivepython/blob/master/chapter02/sec18_positional_arguments.py)
-19. キーワード引数を使ってオプション機能を提供する
+19. [キーワード引数を使ってオプション機能を提供する](https://github.com/ku2ma2/effectivepython/blob/master/chapter02/sec19_keyword_arguments.py)
 20. 動的デフォルト引数ではNoneとドキュメンテーション文字列(docstring)を使おう
 21. キーワードのみの引数(keyword-only argument)を使って明確にする
 

--- a/chapter02/sec20_dynamic_arguments.py
+++ b/chapter02/sec20_dynamic_arguments.py
@@ -1,0 +1,32 @@
+"""
+項目20: 動的なデフォルト引数を指定するときはNoneとdocstringsを使う
+
+Use None and Docstrings to Specify Dynamic Default Arguments
+
+- 関数の引数は、位置またはキーワードによって指定可能
+- キーワード引数は、位置引数だけでは紛らわしい場合に、各引数の目的を明確にする
+- デフォルト値を設定したキーワード引数は、関数が別の場所に使われている状態でも新たな振る舞いを追加する事を容易にする
+- オプション(あってもなくても良い)のキーワード引数は位置ではなくキーワードで常に渡すべきである
+"""
+
+from datetime import datetime
+
+
+def log_message(message, when=None):
+    """
+    ログメッセージを日時と同時に表示
+
+    Args:
+        message: 出力するメッセージ
+        when: メッセージを出力した際のdatetime日時
+              何も与えられない場合は利用された時点での日時
+    """
+
+    if when is None:
+        when = datetime.now()
+
+    return "{}: {}".format(message, when)
+
+
+if __name__ == "__main__":
+    print(log_message('aa'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 coverage==4.4.1
+freezegun==0.3.9
+python-dateutil==2.6.1
+six==1.11.0

--- a/tests/test_sec20_dynamic_arguments.py
+++ b/tests/test_sec20_dynamic_arguments.py
@@ -1,0 +1,47 @@
+"""
+項目20: 動的なデフォルト引数を指定するときはNoneとdocstringsを使うのテスト
+"""
+
+import sys
+import os
+import unittest
+import freezegun
+from datetime import datetime
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../chapter02')
+
+from sec20_dynamic_arguments import *
+
+
+class TestDynamicArguments(unittest.TestCase):
+    """
+    ログを出力する
+    """
+
+    def test_noarg_when(self):
+        """
+        whenが設定されていない場合はその時の日時を使う
+        freezeを使って日時設定している
+        """
+        expected = "Hello: 2017-10-20 09:27:31.885687"
+
+        with freezegun.freeze_time('2017-10-20 09:27:31.885687'):
+            actual = log_message('Hello')
+
+        self.assertEqual(actual, expected)
+
+    def test_in_when(self):
+        """
+        whenが設定されていない場合はその時の日時を使う
+        freezeを使って日時設定している
+        """
+        expected = "Hello: 2017-10-20 09:27:32.885687"
+
+        with freezegun.freeze_time('2017-10-20 09:27:32.885687'):
+            actual = log_message('Hello', datetime.now())
+
+        self.assertEqual(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### 項目20: 動的なデフォルト引数を指定するときはNoneとdocstringsを使う

- 関数の引数は、位置またはキーワードによって指定可能
- キーワード引数は、位置引数だけでは紛らわしい場合に、各引数の目的を明確にする
- デフォルト値を設定したキーワード引数は、関数が別の場所に使われている状態でも新たな振る舞いを追加する事を容易にする
- オプション(あってもなくても良い)のキーワード引数は位置ではなくキーワードで常に渡すべきである