### PR TITLE
finish section 21 keyword-only arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Effective Python のコードメモ
 17. [引数を介したイテレーションは防御的に行う](https://github.com/ku2ma2/effectivepython/blob/master/chapter02/sec17_defensive_iterator.py)
 18. [可変長引数で視認性をあげる](https://github.com/ku2ma2/effectivepython/blob/master/chapter02/sec18_positional_arguments.py)
 19. [キーワード引数を使ってオプション機能を提供する](https://github.com/ku2ma2/effectivepython/blob/master/chapter02/sec19_keyword_arguments.py)
-20. 動的デフォルト引数ではNoneとドキュメンテーション文字列(docstring)を使おう
+20. [動的デフォルト引数ではNoneとドキュメンテーション文字列(docstring)を使おう](https://github.com/ku2ma2/effectivepython/blob/master/chapter02/sec20_dynamic_arguments.py)
 21. キーワードのみの引数(keyword-only argument)を使って明確にする
 

--- a/chapter02/sec21_keyword_only_arguments.py
+++ b/chapter02/sec21_keyword_only_arguments.py
@@ -1,0 +1,57 @@
+"""
+項目21: キーワード専用引数で明確さを高める
+
+Enforce Clarity with Keyword-Only Arguments
+
+- 関数の引
+"""
+
+from datetime import datetime
+
+
+def safe_division(number, divisor, *,
+                  ignore_overflow=False,
+                  ignore_zero_division=False):
+    """
+    除算するだけの関数だが通常想定されないような場合も対処するようにする。
+    結果がFloatをオーバーフローした場合 -> ignore_overflow が True ならば 0 を返す
+    0で除算 -> ignore_zero_division が True ならば inf(無限大) を返す
+    中央の「*」がキモで、なくても良くても良いけど後ろに続くのはキーワード引数として
+    扱わないといけないという事を強制している
+
+    Args:
+        number, divisor: 除算する数
+        ignore_overflow: 結果がオーバーフローしても強制的に処理
+        ignore_zero_division: 0で除算して例外になっても強制的に処理
+
+    >>> # ignore_zero_divisionを設定
+    >>> safe_division(1.0, 10**500, ignore_overflow=True, \
+    ignore_zero_division=False)
+    0
+    >>> # ignore_zero_division を設定
+    >>> safe_division(1.0, 0, ignore_overflow=False, ignore_zero_division=True)
+    inf
+    >>> # キーワード引数を設定しないとエラー
+    >>> safe_division(1.0, 10**500, True)
+    Traceback (most recent call last):
+    ...
+    TypeError: safe_division() takes 2 positional arguments but 3 were given
+    """
+
+    try:
+        return number / divisor
+    except OverflowError:
+        if ignore_overflow:
+            return 0
+        else:
+            raise
+
+    except ZeroDivisionError:
+        if ignore_zero_division:
+            return float('inf')
+        else:
+            raise
+
+
+if __name__ == "__main__":
+    pass

--- a/chapter02/sec21_keyword_only_arguments.py
+++ b/chapter02/sec21_keyword_only_arguments.py
@@ -3,7 +3,8 @@
 
 Enforce Clarity with Keyword-Only Arguments
 
-- 関数の引
+- キーワード引数は関数呼び出しの意図を明確にする
+- キーワード専用引数を設定する事で複数の論理フラッグなどの紛らわしさを軽減できる
 """
 
 from datetime import datetime

--- a/tests/test_sec21_keyword_only_arguments.py
+++ b/tests/test_sec21_keyword_only_arguments.py
@@ -1,0 +1,50 @@
+"""
+項目20: 動的なデフォルト引数を指定するときはNoneとdocstringsを使うのテスト
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../chapter02')
+
+from sec21_keyword_only_arguments import *
+
+
+class TestKeyworOnlyArguments(unittest.TestCase):
+    """
+    ログを出力する
+    """
+
+    def test_ignore_overflow(self):
+        """
+        ignore_overflow が True ならば 0 を返す
+        """
+        expected = 0
+        actual = safe_division(1.0, 10**500,
+                               ignore_overflow=True,
+                               ignore_zero_division=False)
+
+        self.assertEqual(actual, expected)
+
+    def test_ignore_zero_division(self):
+        """
+        ignore_zero_division が True ならば inf(無限大) を返す
+        """
+        expected = float('inf')
+        actual = safe_division(1.0, 0,
+                               ignore_overflow=False,
+                               ignore_zero_division=True)
+
+        self.assertEqual(actual, expected)
+
+    def test_keyword_arguments_type_error(self):
+        """ 
+        キーワード引数を呼び出し元で設定しないとエラー
+        """
+        with self.assertRaises(TypeError):
+            safe_division(1.0, 0, False, True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### 項目21: キーワード専用引数で明確さを高める

- キーワード引数は関数呼び出しの意図を明確にする
- キーワード専用引数を設定する事で複数の論理フラッグなどの紛らわしさを軽減できる