### PR TITLE
Finish section 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Effective Python のコードメモ
 
 22. [辞書やタプルで記録管理するよりもヘルパークラスを使う](https://github.com/ku2ma2/effectivepython/blob/master/chapter03/sec22_helper_class.py)
 23. [単純なインタフェースにはクラスの代わりに関数を使う](https://github.com/ku2ma2/effectivepython/blob/master/chapter03/sec23_callable_class.py)
-24. @classmethodポリモルフィズムを使ってオブジェクトをジェネリックに
+24. [@classmethodポリモルフィズムを使ってオブジェクトをジェネリックに](https://github.com/ku2ma2/effectivepython/blob/master/chapter03/sec24_classmethod_prolymorphism.py)
 25. 親クラスを superを使って初期化する
 26. 多重継承は mix-inユーティリティクラスだけに使う
 27. プライベート属性よりはパブリック属性が好ましい

--- a/tests/test_sec25_super_class.py
+++ b/tests/test_sec25_super_class.py
@@ -8,36 +8,21 @@ import unittest
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../chapter03')
 
-from sec23_callable_class import *
+from sec25_super_class import *
 
 
-class TestCountMissing(unittest.TestCase):
+class TestMyBaseClass(unittest.TestCase):
     """
-    内部カウンタインターフェースのテスト
+    super表記で引数を省略できるかどうかのテスト
     """
 
-    def test_countup(self):
+    def test_assert_super(self):
         """
-        呼び出されるたびに クラス変数 added が上がっていく(インクリメントされる)。
+        内容は同じだが表記の違うsuperで同じ結果になるかどうかのテスト
         """
-        counter = CountMissing()
-        counter()
-        actual = counter.added
-        expected = 1
+        actual = Explicit(10).value
+        expected = Implicit(10).value
         self.assertEqual(actual, expected)
-
-        # 再度カウントアップすると2になる
-        counter()
-        actual = counter.added
-        expected = 2
-        self.assertEqual(actual, expected)
-
-    def test_callable(self):
-        """
-        クラスメソッドを関数のように呼べるかどうかの確認 __call__
-        """
-        counter = CountMissing()
-        self.assertTrue(callable(counter))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### 項目25: 親クラスをsuperを使って初期化する

-  Pythonの 標準メソッドの解決順序(MRO)はスーパークラスの初期化順序とダイヤモンド継承の問題を解決する
- 親クラスを初期化するには、常に組み込み関数superを使う