### PR TITLE
Finish section 26 mixin

### DIFF
--- a/chapter03/sec26_mixin.py
+++ b/chapter03/sec26_mixin.py
@@ -36,5 +36,16 @@ class ToDictMixin(object):
             return value
 
 
+class BinaryTree(ToDictMixin):
+    """
+    二分木の辞書表現
+    """
+
+    def __init__(self, value, left=None, right=None):
+        self.value = value
+        self.left = left
+        self.right = right
+
+
 if __name__ == "__main__":
     pass

--- a/chapter03/sec26_mixin.py
+++ b/chapter03/sec26_mixin.py
@@ -21,7 +21,13 @@ class ToDictMixin(object):
         """
         return self._traverse_dict(self.__dict__)
 
-    def _traverse_dict(self, key, value):
+    def _traverse_dict(self, instance_dict):
+        output = {}
+        for key, value in instance_dict.items():
+            output[key] = self._traverse(key, value)
+        return output
+
+    def _traverse(self, key, value):
         """ 各属性によって辞書表現に対応するように変更
         """
         if isinstance(value, ToDictMixin):

--- a/tests/test_sec26_mixin.py
+++ b/tests/test_sec26_mixin.py
@@ -1,0 +1,37 @@
+"""
+項目25: 親クラスをsuperを使って初期化する
+"""
+
+import sys
+import os
+import unittest
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../chapter03')
+
+from sec26_mixin import *
+
+
+class TestToDictMixin(unittest.TestCase):
+    """
+    Pythonオブジェクトを辞書表現にシリアライズのテスト
+    """
+
+    def test_binary_tree(self):
+        """
+        二分木を作ってみる
+        """
+        tree = BinaryTree(10,
+                          left=BinaryTree(7, right=BinaryTree(9)),
+                          right=BinaryTree(13, left=BinaryTree(11)))
+        expected = {'left': {'left': None,
+                             'right': {'left': None, 'right': None, 'value': 9},
+                             'value': 7},
+                    'right': {'left': {'left': None, 'right': None, 'value': 11},
+                              'right': None,
+                              'value': 13},
+                    'value': 10}
+        self.assertEqual(tree.to_dict(), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### 項目26: 多重継承は mix-in ユーティリティクラスだけに使う

- mix-in クラスで同じ結果が得られるなら、多重継承を使うのを止める
- インスタンスレベルでプラグイン可能な振る舞いを使い、mix-in クラスが必要な時に、クラス毎にカスタマイズする
- 単純な振る舞いから複雑な機能を構成するように mix-in を組み合わせて作る