### PR TITLE
Finish section 31 

### DIFF
--- a/chapter04/sec31_reusable_property.py
+++ b/chapter04/sec31_reusable_property.py
@@ -40,7 +40,8 @@ class Homework(object):
     @grade.setter
     def grade(self, value):
         """
-        成績評価のセッター。0〜100以内出ないとValueError
+        成績評価のセッター
+        100点満点のテストなので0〜100以内である事を保証する
         """
         if not (0 <= value <= 100):
             raise ValueError('Grade must be between 0 and 100')

--- a/chapter04/sec31_reusable_property.py
+++ b/chapter04/sec31_reusable_property.py
@@ -7,7 +7,15 @@ Use Descriptors for Reusable @property Methods
 - WeakKeyDirectoryを用いて、ディスクリプタクラスがメモリリークを起こさないようにする
 - __getattribute__ がディスクリプタプロトコルをどのように使って属性の取得や設定を行なっているか、正確に把握しようとして立ち往生をしない。
 
+### 所感
+
+- 実際は、ここのGradeの所のメモリリークまで考えが至らない気がする。
+- 便利そうだけど思い出せるかな…
+- https://qiita.com/pashango2/items/fb1e5e79589279c5a861
+
 """
+
+from weakref import WeakKeyDictionary
 
 
 class Homework(object):
@@ -40,15 +48,40 @@ class Homework(object):
         self._grade = value
 
 
-class Exam(object):
+class Grade(object):
     def __init__(self):
-        self._writing_grade = 0
-        self._math_grade = 0
+        """
+        コンストラクタ
+        WeakKeyDictionaryを使って実行時にプログラムでインスタンスの
+        最後に残っている参照が、その辞書のキー集合で保持されているのだけだと
+        分かったら利用されているオブジェクトから削除する
+        """
+        self._values = WeakKeyDictionary()
 
-    @staticmethod
-    def _check_grade(value):
+    def __get__(self, instance, instance_type):
+        """
+        Grede内の属性に代入
+        辞書 _values の中から instance の名前で取得
+        """
+        if instance is None:
+            return self
+        return self._values.get(instance, 0)
+
+    def __set__(self, instance, value):
+        """
+        Grede内の属性を取得
+        辞書 _values の中から instance の名前で設定
+        代入する value が 0 〜 100 でなければ ValueError
+        """
         if not (0 <= value <= 100):
             raise ValueError('Grade must be between 0 and 100')
+        self._values[instance] = value
+
+
+class Exam(object):
+    math_grade = Grade()
+    writing_grade = Grade()
+    science_grade = Grade()
 
 
 if __name__ == "__main__":

--- a/tests/test_sec31_reusable_property.py
+++ b/tests/test_sec31_reusable_property.py
@@ -28,6 +28,40 @@ class TestHomework(unittest.TestCase):
 
         self.assertEqual(actual, expected)
 
+    def test_valueerror_property(self):
+        """
+        属性に 0 ~ 100 以内では無い値を代入すると ValueError
+        """
+        with self.assertRaises(ValueError):
+            galileo = Homework()
+            galileo.grade = 101
+
+
+class TestExam(unittest.TestCase):
+    """
+    試験(Exam)のテスト
+    """
+
+    def test_property_in_grade(self):
+        """
+        Gradeに各属性の設定ができるかのテスト
+        """
+        first_exam = Exam()
+        first_exam.writing_grade = 82
+        second_exam = Exam()
+        second_exam.writing_grade = 75
+
+        self.assertEqual(first_exam.writing_grade, 82)
+        self.assertEqual(second_exam.writing_grade, 75)
+
+    def test_valueerror_in_grade(self):
+        """
+        Grade の 0 〜 100以内では無い属性を入れると ValueError
+        """
+        with self.assertRaises(ValueError):
+            exam = Exam()
+            exam.writing_grade = 101
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### 項目31: ディスクリプタを使って @property デコレータのメソッドを再利用可能にする

Use Descriptors for Reusable @property Methods

- ディスクリプタを定義して、@property メソッドの振る舞いや確認作業を再利用する
- WeakKeyDirectoryを用いて、ディスクリプタクラスがメモリリークを起こさないようにする
- __getattribute__ がディスクリプタプロトコルをどのように使って属性の取得や設定を行なっているか、正確に把握しようとして立ち往生をしない。

### 所感

- 実際は、ここのGradeの所のメモリリークまで考えが至らない気がする。
- 便利そうだけど思い出せるかな…
- https://qiita.com/pashango2/items/fb1e5e79589279c5a861
